### PR TITLE
Extend provider to revoke access token

### DIFF
--- a/src/Provider/AbstractExtendedProvider.php
+++ b/src/Provider/AbstractExtendedProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Bogstag\OAuth2\Client\Provider;
+
+use GuzzleHttp\Exception\BadResponseException;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Token\AccessTokenInterface;
+use Psr\Http\Message\RequestInterface;
+
+abstract class AbstractExtendedProvider extends AbstractProvider
+{
+    /**
+     * Returns the base URL for revoking an access token.
+     *
+     * Eg. https://oauth.service.com/revoke
+     *
+     * @return string
+     */
+    abstract public function getBaseRevokeAccessTokenUrl();
+
+    /**
+     * Revokes an access token.
+     *
+     * @param AccessTokenInterface $token
+     * @throws BadResponseException
+     * @return void
+     */
+    public function revokeAccessToken(AccessTokenInterface $token)
+    {
+        $params = [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->clientSecret,
+            'token'         => $token->getToken(),
+        ];
+
+        $request = $this->getRevokeAccessTokenRequest($params);
+
+        $this->getResponse($request);
+    }
+
+    /**
+     * Returns a prepared request for revoking an access token.
+     *
+     * @param array $params Post body parameters
+     * @return RequestInterface
+     */
+    protected function getRevokeAccessTokenRequest(array $params)
+    {
+        $method = $this->getRevokeAccessTokenMethod();
+        $url    = $this->getBaseRevokeAccessTokenUrl();
+
+        return $this->getRequest($method, $url, $params);
+    }
+
+    /**
+     * Returns the method to use when revoking an access token.
+     *
+     * @return string HTTP method
+     */
+    protected function getRevokeAccessTokenMethod()
+    {
+        return self::METHOD_POST;
+    }
+}

--- a/src/Provider/Trakt.php
+++ b/src/Provider/Trakt.php
@@ -1,6 +1,5 @@
 <?php namespace Bogstag\OAuth2\Client\Provider;
 
-use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
@@ -10,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
  * Class Trakt
  * @package Bogstag\OAuth2\Client\Provider
  */
-class Trakt extends AbstractProvider
+class Trakt extends AbstractExtendedProvider
 {
     use BearerAuthorizationTrait;
 
@@ -46,6 +45,14 @@ class Trakt extends AbstractProvider
     public function getBaseAccessTokenUrl(array $params)
     {
         return $this->baseUrlApi.'/oauth/token';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBaseRevokeAccessTokenUrl()
+    {
+        return $this->baseUrlApi.'/oauth/revoke';
     }
 
     /**


### PR DESCRIPTION
The OAuth2 specification has no method for revoking access tokens, but the Trakt API does support this. This PR extends the `AbstractProvider` to support revoking access tokens in a similar fashion to getting them.

https://trakt.docs.apiary.io/#reference/authentication-oauth/revoke-token/revoke-an-access_token